### PR TITLE
Add mimalloc back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,6 +1688,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1752,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -4116,6 +4135,7 @@ dependencies = [
  "ferrisetw",
  "log",
  "lru",
+ "mimalloc",
  "parking_lot",
  "reqwest",
  "rpassword",

--- a/wm-client/Cargo.toml
+++ b/wm-client/Cargo.toml
@@ -17,6 +17,7 @@ config-file = { workspace = true }
 ferrisetw = { workspace = true }
 log = { workspace = true }
 lru = "^0.16.1"
+mimalloc = "^0.1.48"
 parking_lot = "^0.12.5"
 reqwest = { workspace = true }
 rpassword = { workspace = true }

--- a/wm-client/src/main.rs
+++ b/wm-client/src/main.rs
@@ -11,7 +11,7 @@ use async_compression::tokio::write::ZstdDecoder;
 use clap::Parser;
 use config_file::FromConfigFile;
 use log::{debug, error, info, warn};
-// use mimalloc::MiMalloc;
+use mimalloc::MiMalloc;
 use tokio::runtime::Builder;
 use tokio::time::sleep;
 use tokio::{fs, io, signal, task};
@@ -28,8 +28,8 @@ use wm_common::service::service_manager::ServiceManager;
 use wm_common::service::status::ServiceState;
 use wm_common::utils::to_c_string;
 
-// #[global_allocator]
-// static GLOBAL: MiMalloc = MiMalloc;
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn _open_registry_password(config: &Configuration) -> RegistryKey {
     RegistryKey::new(&to_c_string(config.password_registry_key.clone()))


### PR DESCRIPTION
Add [`mimalloc`](https://crates.io/crates/mimalloc) back as the default allocator for client.